### PR TITLE
Adding URL source

### DIFF
--- a/public/sample-workbook.json
+++ b/public/sample-workbook.json
@@ -1,0 +1,11 @@
+{
+    "name": "example",
+    "phrases": [
+        {
+            "sourceLanguageCode": "en-Us",
+            "source": "The apple is red",
+            "targetLanguageCode": "es-Mx",
+            "target": "La manzana es roja"
+        }
+    ]
+}

--- a/src/components/Workbook/Sources/UrlSource.js
+++ b/src/components/Workbook/Sources/UrlSource.js
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import LinkIcon from '@material-ui/icons/Link';
+import TextField from '@material-ui/core/TextField';
+
+export async function UrlLoader(url) {
+  let data = null;
+
+  data = await fetch(url)
+    .then(r => r.json())
+  ;
+
+  return data;
+}
+
+export function UrlDialog({ open, onClose, onLoad }) {
+  const [ url, setUrl ] = React.useState(null);
+
+  const submit = async (e) => {
+    e.stopPropagation();
+
+    try {
+      const data = await UrlLoader(url);
+      onLoad(data);
+    } catch(e) {
+      window.alert("Failed to load data from URL:" + e.message);
+      throw e;
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} aria-labelledby="form-dialog-title">
+      <DialogTitle id="form-dialog-title">Enter URL</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Enter a URL to load a workbook from.
+        </DialogContentText>
+        <TextField
+            autoFocus
+            margin="dense"
+            id="url"
+            label="URL"
+            inputProps={{"data-testid":"url"}}
+            type="url"
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyUp={(e) => setUrl(e.target.value)}
+            fullWidth
+          />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          Cancel
+        </Button>
+        <Button onClick={submit} color="primary">
+          Submit
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export function UrlSource({ onSourceChange }) {
+  const [ open, setOpen ] = React.useState(false);
+
+  const onClick = (e) => {
+    e.stopPropagation();
+    setOpen(true);
+  };
+
+  const onLoad = (data) => {
+    setOpen(false);
+    onSourceChange(data);
+  };
+
+  const onClose = (e) => {
+    e.stopPropagation();
+    setOpen(false);
+  };
+
+  return (
+    <ListItem button onClick={onClick}>
+      <ListItemIcon>
+        <LinkIcon />
+      </ListItemIcon>
+      <ListItemText primary='URL' secondary='Load a workbook from a URL' />
+      <UrlDialog open={open} onLoad={onLoad} onClose={onClose} />
+    </ListItem>
+  );
+}

--- a/src/components/Workbook/Sources/UrlSource.test.js
+++ b/src/components/Workbook/Sources/UrlSource.test.js
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import { render, fireEvent, wait } from '@testing-library/react';
+
+import {
+  UrlLoader,
+  UrlDialog,
+  UrlSource,
+} from './UrlSource';
+
+
+describe('UrlDialog', () => {
+  let getByLabelText;
+  let getByText;
+
+  beforeEach(() => {
+    ({
+      getByText,
+      getByLabelText,
+    } = render(
+      <UrlSource
+        />
+    ));
+  });
+
+  it('should show a button', () => {
+    const element = getByText(/^URL$/);
+    expect(element).toBeInTheDocument();
+  });
+
+it('should show UrlDialog on click', () => {
+    const element = getByText(/^URL$/);
+    expect(element).toBeInTheDocument();
+
+    fireEvent.click(element);
+
+    const urlField = getByLabelText(/URL/);
+    expect(urlField).toBeInTheDocument();
+  });
+});
+
+describe('UrlLoader', () => {
+  it('should load data', async () => {
+    const input = {
+      name: "some_data"
+    };
+
+    const encoded = btoa(JSON.stringify(input));
+
+    const data = await UrlLoader(`data:application/json;base64,${encoded}`);
+
+    expect(data.name).toEqual(input.name);
+  });
+});
+
+describe('UrlDialog', () => {
+  let getByTestId;
+  let getByLabelText;
+  let getByText;
+  let onClose;
+  let onLoad;
+
+  beforeEach(() => {
+    onClose = jest.fn();
+    onLoad = jest.fn();
+
+    ({
+      getByTestId,
+      getByLabelText,
+      getByText,
+    } = render(
+      <UrlDialog
+        open={true}
+        onClose={onClose}
+        onLoad={onLoad}
+        />
+    ));
+  });
+
+  it('should have a url field', () => {
+    const element = getByLabelText(/URL/);
+    expect(element).toBeInTheDocument();
+  });
+
+  it('should return data on submit', async () => {
+    const urlField = getByTestId(/url/);
+    expect(urlField).toBeInTheDocument();
+
+    const input = {
+      name: "some_data"
+    };
+
+    const encoded = `data:application/json;base64,${btoa(JSON.stringify(input))}`;
+
+    fireEvent.change(urlField, {
+      target: {
+        value: encoded
+      }
+    });
+
+    const submitButton = getByText(/Submit/);
+
+    fireEvent.click(submitButton);
+
+    await wait(() => expect(onLoad).toHaveBeenCalled());
+
+    expect(onLoad).toHaveBeenCalledWith(input);
+  });
+});

--- a/src/components/Workbook/WorkbookSourceSelector.js
+++ b/src/components/Workbook/WorkbookSourceSelector.js
@@ -3,12 +3,13 @@ import List from '@material-ui/core/List';
 
 import { SampleSource } from './Sources/SampleSource';
 import { FileSource } from './Sources/FileSource';
+import { UrlSource } from './Sources/UrlSource';
 
 export function WorkbookSourceSelector({ onSourceChange }) {
-
   return (
     <List>
       <SampleSource onSourceChange={onSourceChange} />
+      <UrlSource onSourceChange={onSourceChange} />
       <FileSource onSourceChange={onSourceChange} />
     </List>
   );


### PR DESCRIPTION
This pull request adds a "URLSource". Valid urls from remote sources and be used. As a bonus valid [data uris](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) can also be used to load workbook data.

**Example DATA URI**
```
data:text/plain;base64,ewogICAgIm5hbWUiOiAiZXhhbXBsZSIsCiAgICAicGhyYXNlcyI6IFsKICAgICAgICB7CiAgICAgICAgICAgICJzb3VyY2VMYW5ndWFnZUNvZGUiOiAiZW4tVXMiLAogICAgICAgICAgICAic291cmNlIjogIlRoZSBhcHBsZSBpcyByZWQiLAogICAgICAgICAgICAidGFyZ2V0TGFuZ3VhZ2VDb2RlIjogImVzLU14IiwKICAgICAgICAgICAgInRhcmdldCI6ICJMYSBtYW56YW5hIGVzIHJvamEiCiAgICAgICAgfQogICAgXQp9
```

![image](https://user-images.githubusercontent.com/899367/76353820-cfb5ff80-62e7-11ea-9758-ff39f417e142.png)


refs: #10